### PR TITLE
Update `zeebe-hazelcast-exporter`

### DIFF
--- a/operate-simple-monitor/application.yaml
+++ b/operate-simple-monitor/application.yaml
@@ -125,4 +125,4 @@ zeebe:
             ignoreVariablesAbove: 32677
       hazelcast:
         className: io.zeebe.hazelcast.exporter.HazelcastExporter
-        jarPath: exporters/zeebe-hazelcast-exporter-0.10.0.jar
+        jarPath: exporters/zeebe-hazelcast-exporter-1.0.0.jar

--- a/operate-simple-monitor/docker-compose.yml
+++ b/operate-simple-monitor/docker-compose.yml
@@ -19,7 +19,7 @@ services:
       - "9600:9600"
       - "5701:5701"
     volumes:
-      - ../lib/zeebe-hazelcast-exporter-0.10.0.jar:/usr/local/zeebe/exporters/zeebe-hazelcast-exporter-0.10.0.jar
+      - ../lib/zeebe-hazelcast-exporter-1.0.0.jar:/usr/local/zeebe/exporters/zeebe-hazelcast-exporter-1.0.0.jar
       - ./application.yaml:/usr/local/zeebe/config/application.yaml
     networks:
       - zeebe_network

--- a/simple-monitor/application.yaml
+++ b/simple-monitor/application.yaml
@@ -41,4 +41,4 @@ zeebe:
     exporters:
       hazelcast:
         className: io.zeebe.hazelcast.exporter.HazelcastExporter
-        jarPath: exporters/zeebe-hazelcast-exporter-0.10.0.jar
+        jarPath: exporters/zeebe-hazelcast-exporter-1.0.0.jar

--- a/simple-monitor/docker-compose.yml
+++ b/simple-monitor/docker-compose.yml
@@ -15,7 +15,7 @@ services:
       - "9600:9600"
       - "5701:5701"
     volumes:
-      - ../lib/zeebe-hazelcast-exporter-0.10.0.jar:/usr/local/zeebe/exporters/zeebe-hazelcast-exporter-0.10.0.jar
+      - ../lib/zeebe-hazelcast-exporter-1.0.0.jar:/usr/local/zeebe/exporters/zeebe-hazelcast-exporter-1.0.0.jar
       - ./application.yaml:/usr/local/zeebe/config/application.yaml
     networks:
       - zeebe_network

--- a/zeeqs/application.yaml
+++ b/zeeqs/application.yaml
@@ -41,4 +41,4 @@ zeebe:
     exporters:
       hazelcast:
         className: io.zeebe.hazelcast.exporter.HazelcastExporter
-        jarPath: exporters/zeebe-hazelcast-exporter-0.10.0.jar
+        jarPath: exporters/zeebe-hazelcast-exporter-1.0.0.jar

--- a/zeeqs/docker-compose.yml
+++ b/zeeqs/docker-compose.yml
@@ -15,7 +15,7 @@ services:
       - "9600:9600"
       - "5701:5701"
     volumes:
-      - ../lib/zeebe-hazelcast-exporter-0.10.0.jar:/usr/local/zeebe/exporters/zeebe-hazelcast-exporter-0.10.0.jar
+      - ../lib/zeebe-hazelcast-exporter-1.0.0.jar:/usr/local/zeebe/exporters/zeebe-hazelcast-exporter-1.0.0.jar
       - ./application.yaml:/usr/local/zeebe/config/application.yaml
     networks:
       - zeebe_network


### PR DESCRIPTION
The version of the library `zeebe-hazelcast-exporter` is not compatible with the current version of `zeebe`. This commit update it to the last version `1.0.0` and update configuration files.

This Pull Request resolves #41.