### PR TITLE
Update git clone instructions

### DIFF
--- a/operate/README.md
+++ b/operate/README.md
@@ -18,7 +18,7 @@ The components that will be started with this profile:
 * Clone this repository:
 
 ```bash
-git clone https://github.com/zeebe-io/zeebe-docker-compose
+git clone https://github.com/camunda-community-hub/zeebe-docker-compose.git
 ```
 
 ## Start the containers


### PR DESCRIPTION
I think it would be nice to update the git clone instructions to reflect the new location of this repository (as the previous command won't work anymore)